### PR TITLE
feature: context menu added

### DIFF
--- a/background.js
+++ b/background.js
@@ -10,10 +10,37 @@ chrome.runtime.onInstalled.addListener(() => {
          }])     
     });
 
+    chrome.contextMenus.create({
+                	        "id": "tails-mouse-footpring-switch",
+                                "title": "STOP Extension"
+                               });
+
 });
 
-chrome.runtime.onMessage.addListener((msg) => {
+chrome.contextMenus.onClicked.addListener(() => {
+  if(localStorage.type === 'stop') {
+    chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
 
+              chrome.tabs.sendMessage(
+                  tabs[0].id,
+                 {
+                        name: localStorage.pointerName,
+                        path: localStorage.pointerPath,
+                        type: 'moving'})
+              });
+   
+  } else {
+         chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
+
+              chrome.tabs.sendMessage(
+                  tabs[0].id,
+                 {type: 'stop'})
+              });
+
+  }
+})
+
+chrome.runtime.onMessage.addListener((msg) => {
   if (msg.type === 'moving') {
       localStorage.pointerName = msg.name;      
       localStorage.pointerPath = msg.path;
@@ -24,7 +51,9 @@ chrome.runtime.onMessage.addListener((msg) => {
           tabs[0].id,
           {file: './functions/' + msg.name + '.js'} );
       });
-      
+    
+      chrome.contextMenus.update( "tails-mouse-footpring-switch", {"title": "STOP Extension"});
+
     } else if (msg.type === 'stop') {
       localStorage.type = 'stop';
 
@@ -33,6 +62,8 @@ chrome.runtime.onMessage.addListener((msg) => {
           tabs[0].id,
           {file: './functions/' + 'stop' + '.js'} );
     });
+
+      chrome.contextMenus.update( "tails-mouse-footpring-switch", {"title": "START Extension"});
 
     } else if (msg.type === 'check') {
             chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {              

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Mouse Footprint Tailing",
     "version": "0.0.3.1",
-    "permissions": ["activeTab", "declarativeContent", "https://*/*"],
+    "permissions": ["activeTab", "declarativeContent", "contextMenus", "https://*/*"],
     "content_scripts": [
       {
         "matches": ["https://*/*"],


### PR DESCRIPTION
Reference: #4 

Context menu on chrome browser to stop/start extension is added. Whenever clicked stop extension button on popup.html or stop extension on context menu, `STOP Extension'/`START Extension' will be changed on `localStorage.type`. 